### PR TITLE
Add Custom String Interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A small library to convert a tree structure into a `String`, designed to be used
 
 1. Include the framework in your project
 2. Conform your type to be `TreeRepresentable`
-3. `let treeString = TreePrinter.printTree(root: rootNodeOfYourTree)`
+3a. `let treeString = TreePrinter.printTree(root: rootNodeOfYourTree)`
+3b. `let treeString = "\(tree: rootNodeOfYourTree)"`
 
 # Example
 
@@ -34,6 +35,7 @@ Then, you can easily debug a tree as such:
 func someFunctionYoureTesting() {
     var treeRoot: SomeTreeStructure = /* Your tree */
     print(TreePrinter.printTree(root: treeRoot))
+    // or alternatively: print("\(tree: treeRoot)")
 }
 ```
 
@@ -68,6 +70,7 @@ as such:
 
 ```swift
 TreePrinter.printTree(root: treeRoot, options: treePrinterOptions)
+"\(tree: treeRoot, options: treePrinterOptions)")
 ```
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ A small library to convert a tree structure into a `String`, designed to be used
 
 1. Include the framework in your project
 2. Conform your type to be `TreeRepresentable`
-3a. `let treeString = TreePrinter.printTree(root: rootNodeOfYourTree)`
-3b. `let treeString = "\(tree: rootNodeOfYourTree)"`
+3. `let treeString = TreePrinter.printTree(root: rootNodeOfYourTree)` or `let treeString = "\(tree: rootNodeOfYourTree)"`
 
 # Example
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ as such:
 
 ```swift
 TreePrinter.printTree(root: treeRoot, options: treePrinterOptions)
+// alternatively:
 "\(tree: treeRoot, options: treePrinterOptions)")
 ```
 

--- a/Sources/TreePrinter/TreePrinter.swift
+++ b/Sources/TreePrinter/TreePrinter.swift
@@ -129,3 +129,16 @@ public class TreePrinter {
         return retVal
     }
 }
+
+public extension String.StringInterpolation {
+    
+    /// Creates a `String` representation of a tree structure.
+    /// - Parameters:
+    ///   - tree: Root of the tree; must conform to `TreeReprsentable`
+    ///   - options: Optional set of options to configure how the output looks
+    mutating func appendInterpolation<Tree: TreeRepresentable>(tree: Tree,
+                                                               options: TreePrinter.TreePrinterOptions = TreePrinter.TreePrinterOptions())
+    {
+        appendInterpolation(TreePrinter.printTree(root: tree, options: options))
+    }
+}

--- a/Tests/TreePrinterTests/TreePrinterTests.swift
+++ b/Tests/TreePrinterTests/TreePrinterTests.swift
@@ -451,6 +451,20 @@ class TreePrinterTests: XCTestCase {
         XCTAssertTrue(lines[15].starts(with: options.finalConnector))
     }
     
+    func testStringInterpolation() {
+        let tree = TreeNode(title: "Root",
+                            subNodes: [
+                                TreeNode(title: "Level One", subNodes: [
+                                    TreeNode(title: "Level Two A", subNodes: []),
+                                    TreeNode(title: "Level Two B", subNodes: [])
+                                ])
+                            ])
+        let options = TreePrinter.TreePrinterOptions(spacesPerDepth: 4, spacer: "-", verticalLine: "|", intermediateConnector: "*", finalConnector: "?", connectorSuffix: "!")
+
+        XCTAssertEqual("\(tree: tree)", TreePrinter.printTree(root: tree))
+        XCTAssertEqual("\(tree: tree, options: options)", TreePrinter.printTree(root: tree, options: options))
+    }
+    
     private func getMatchCount(_ pattern: String, in haystack: String) -> Int {
         let regex = try! NSRegularExpression(pattern: pattern,
                                              options: .ignoreMetacharacters)


### PR DESCRIPTION
Hi,

This is my first foray into contributing to OpenSource code... so please bear with me (and poke me as needed) if I don't follow best GitHub practices.

Anyhoo... when I came across this project I thought it seemed like a prime use case for Swift's new custom string interpolation... with this PR you'd be able to write:
`"\(tree: rootNode)"` instead of `TreePrinter.printTree(root: rootNode)`

What do you think? Is this something you'd like to include?

I've added a test, and I've tried to align to the indentation style (despite holding my own opinions on the subject 😜). I've also updated the readme, but I wasn't really sure how best to present both use cases.

I hope you find this useful.